### PR TITLE
allow metadata to be customized

### DIFF
--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -1,0 +1,13 @@
+require 'yaml'
+
+describe 'compiled component' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/metadata.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/filters/s3-deployer.compiled.yaml") }
+  
+end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -8,6 +8,6 @@ describe 'compiled component' do
     end      
   end
   
-  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/filters/s3-deployer.compiled.yaml") }
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/metadata/s3-deployer.compiled.yaml") }
   
 end

--- a/tests/metadata.test.yaml
+++ b/tests/metadata.test.yaml
@@ -1,0 +1,10 @@
+test_metadata:
+  type: config
+  name: filters
+  description: test setting additional metadata
+
+test_parameters:
+  APIEndpoint: dev
+
+deployment_metadata: 
+  Key1: Value1   

--- a/tests/metadata.test.yaml
+++ b/tests/metadata.test.yaml
@@ -1,6 +1,6 @@
 test_metadata:
   type: config
-  name: filters
+  name: metadata
   description: test setting additional metadata
 
 test_parameters:


### PR DESCRIPTION
`DeploymentMetadata` can be configured in the yaml file and applied to all objects. 

This retains the existing `deployment` property as a default

The `DeploymentMetadata` could (should) be extended to a use a custom list rather than a dictionary where the key is the filename. This would allow metadata to be applied to specific objects

This could also be extended to allow system defined metadata to be applied to all or some files in the bucket